### PR TITLE
ecpix5: add ecpix5 platform example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,50 @@ jobs:
       - name: Build firmware (rust)
         run: |
           cd firmware
-          ./build.sh
+          BOARD=colorlight_i5 ./build.sh
       - uses: actions/upload-artifact@v3
         with:
           name: firmware-artifacts
           path: |
             build/colorlight_i5/rust-fw.bin
+
+  ubuntu-build-ecpix-5:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: YosysHQ/setup-oss-cad-suite@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: True
+            components: rustfmt, clippy
+            target: riscv32imac-unknown-none-elf
+      - run: cargo install svd2rust
+      - run: svd2rust --version
+      - uses: gregdavill/setup-riscv-gnu-toolchain@v2
+      - run: riscv-none-elf-gcc --version
+      - name: Install python packages
+        run: |
+          python3 -m pip install setuptools
+          python3 -m pip install pycrc
+          python3 -m pip install wheel
+          python3 -m pip install construct
+          python3 -m pip install Sphinx sphinxcontrib-wavedrom meson ninja setuptools_scm Jinja2
+      - run: git submodule update --init --recursive
+      - run: mkdir -p build
+      - run: python3 example-ecpix-5.py --ecppack-compress --cpu-type vexriscv --cpu-variant imac --csr-svd build/lambdaconcept_ecpix5/csr.svd --build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bitstream-artifacts
+          path: |
+            build/lambdaconcept_ecpix5/gateware/lambdaconcept_ecpix5.bit
+            build/lambdaconcept_ecpix5/csr.svd
+      - name: Build firmware (rust)
+        run: |
+          cd firmware
+          BOARD=lambdaconcept_ecpix5 ./build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: firmware-artifacts
+          path: |
+            build/lambdaconcept_ecpix5/rust-fw.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: build & test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   ubuntu-build-colorlight-i5:

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "firmware/deps/rust-litex-hal"]
 	path = firmware/deps/rust-litex-hal
 	url = https://github.com/schnommus/rust-litex-hal
+[submodule "deps/liteeth"]
+	path = deps/liteeth
+	url = https://github.com/enjoy-digital/liteeth
+[submodule "deps/liteiclink"]
+	path = deps/liteiclink
+	url = https://github.com/enjoy-digital/liteiclink

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Basic example of using `eurorack-pmod` inside a LiteX environment with firmware written in Rust.
 
-It consists of a basic SoC that includes one instance of `eurorack-pmod` working alongside a soft RISCV CPU. Currently only tested on Colorlight i5 but should be quite easy to port to other ECP5 boards.
+It consists of a basic SoC that includes one instance of `eurorack-pmod` working alongside a soft RISCV CPU. Currently only tested on Colorlight i5, ECPIX-5 but should be quite easy to port to other ECP5 boards.
 
 # Dependencies
 
@@ -25,13 +25,19 @@ The bitstream and firmware are built in CI inside `.github/workflows/main.yml`, 
 ```
 <from this repository>
 git submodule update --init --recursive
+# e.g. for Colorlight i5
 python3 example-colorlight-i5.py --ecppack-compress --cpu-type vexriscv --cpu-variant imac --csr-svd build/colorlight_i5/csr.svd --build
+# e.g. for ECPIX-5
+python3 example-ecpix-5.py --ecppack-compress --cpu-type vexriscv --cpu-variant imac --csr-svd build/lambdaconcept_ecpix5/csr.svd --build
 ```
 
 # Flashing the bitstream
 
 ```
+# e.g. for Colorlight i5
 openFPGALoader -b colorlight-i5 build/colorlight_i5/gateware/colorlight_i5.bit
+# e.g. for ECPIX-5
+openFPGALoader -b ecpix5 --vid 0x0403 --pid 0x6011 build/lambdaconcept_ecpix5/gateware/lambdaconcept_ecpix5.bit
 ```
 
 # Building the firmware (Rust)
@@ -42,10 +48,13 @@ To build the bindings for LiteX CSRs (`litex-pac`), compile the firmware, and co
 
 ```
 cd firmware/
-./build.sh
+# e.g. for Colorlight i5
+BOARD=colorlight_i5 ./build.sh
+# e.g. for ECPIX-5 with your own OBJCOPY binary --
+BOARD=lambdaconcept_ecpix5 OBJCOPY=riscv64-elf-objcopy ./build.sh
 ```
 
-To see the LiteX terminal and download firmware to the device --
+To see the LiteX terminal and download firmware to the device (again replacing all instances of the board with your own type) --
 
 ```
 <from repo root>

--- a/cmds.sh
+++ b/cmds.sh
@@ -1,7 +1,0 @@
-./example-ecpix-5.py --ecppack-compress --cpu-type vexriscv --cpu-variant imac --csr-svd build/lambdaconcept_ecpix5/csr.svd --build
-
-openFPGALoader -b ecpix5 --vid 0x0403 --pid 0x6011 build/lambdaconcept_ecpix5/gateware/lambdaconcept_ecpix5.bit
-
-cd firmware && ./build.sh
-
-./bin/litex_term --kernel build/lambdaconcept_ecpix5/rust-fw.bin /dev/ttyUSB3 | ~/dev/defmt/target/release/defmt-print --show-skipped-frames -e firmware/litex-fw/target/riscv32imac-unknown-none-elf/release/litex-fw

--- a/cmds.sh
+++ b/cmds.sh
@@ -1,0 +1,7 @@
+./example-ecpix-5.py --ecppack-compress --cpu-type vexriscv --cpu-variant imac --csr-svd build/lambdaconcept_ecpix5/csr.svd --build
+
+openFPGALoader -b ecpix5 --vid 0x0403 --pid 0x6011 build/lambdaconcept_ecpix5/gateware/lambdaconcept_ecpix5.bit
+
+cd firmware && ./build.sh
+
+./bin/litex_term --kernel build/lambdaconcept_ecpix5/rust-fw.bin /dev/ttyUSB3 | ~/dev/defmt/target/release/defmt-print --show-skipped-frames -e firmware/litex-fw/target/riscv32imac-unknown-none-elf/release/litex-fw

--- a/eurorack_pmod_migen/core.py
+++ b/eurorack_pmod_migen/core.py
@@ -10,8 +10,7 @@ SOURCES_ROOT = os.path.join(
         )
 
 class EurorackPmod(Module, AutoCSR):
-    def __init__(self, platform, pads, w=16, output_csr_read_only=True,
-                 create_sample_clk=True):
+    def __init__(self, platform, pads, w=16, output_csr_read_only=True):
         self.w = w
         self.cal_mem_file = os.path.join(SOURCES_ROOT, "cal/cal_mem.hex")
         self.codec_cfg_file = os.path.join(SOURCES_ROOT, "drivers/ak4619-cfg.hex")
@@ -19,11 +18,9 @@ class EurorackPmod(Module, AutoCSR):
 
         # Exposed signals
 
-        self.clk_12mhz = ClockSignal("sys")
+        self.clk_256fs = ClockSignal("clk_256fs")
+        self.clk_fs = ClockSignal("clk_fs")
         self.rst = ResetSignal("sys")
-
-        if create_sample_clk:
-            self.clock_domains.cd_sample_clk = ClockDomain()
 
         self.cal_in0 = Signal((w, True))
         self.cal_in1 = Signal((w, True))
@@ -72,7 +69,8 @@ class EurorackPmod(Module, AutoCSR):
             p_LED_CFG_FILE = self.led_cfg_file,
 
             # Ports (clk + reset)
-            i_clk_12mhz = self.clk_12mhz,
+            i_clk_256fs = self.clk_256fs,
+            i_clk_fs = self.clk_fs,
             i_rst = self.rst,
 
             # Pads (tristate, require different logic to hook these
@@ -90,8 +88,7 @@ class EurorackPmod(Module, AutoCSR):
             o_lrck = pads.lrck,
             o_bick = pads.bick,
 
-            # Ports (sample clocking)
-            o_sample_clk = self.cd_sample_clk.clk if create_sample_clk else None,
+            # Ports (clock at clk_fs)
             o_cal_in0 = self.cal_in0,
             o_cal_in1 = self.cal_in1,
             o_cal_in2 = self.cal_in2,

--- a/example-colorlight-i5.py
+++ b/example-colorlight-i5.py
@@ -9,28 +9,14 @@ LX_DEPENDENCIES = ["riscv", "nextpnr-ecp5", "yosys"]
 # Import lxbuildenv to integrate the deps/ directory
 import lxbuildenv
 
-from migen import *
-
-from litex.gen import *
-
-from litex.build.io import DDROutput
 from litex.build.generic_platform import *
-
-from litex_boards.platforms import colorlight_i5
-
 from litex.soc.cores.clock import *
-from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
-from litex.soc.cores.uart import *
 
-from litex.soc.interconnect.csr import *
-
-from litedram.modules import M12L64322A # Compatible with EM638325-6H.
-from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+from litex_boards.targets.colorlight_i5 import *
 
 from eurorack_pmod_migen.core import *
 from eurorack_pmod_migen.blocks import *
-
 
 _io_eurorack_pmod = [
     ("eurorack_pmod_p2b", 0,
@@ -46,139 +32,53 @@ _io_eurorack_pmod = [
     ),
 ]
 
+def add_eurorack_pmod(soc, sample_rate=48000):
+    soc.platform.add_extension(_io_eurorack_pmod)
 
-# CRG ----------------------------------------------------------------------------------------------
+    # Create 256*Fs clock domain
+    soc.crg.cd_clk_256fs = ClockDomain()
+    soc.crg.pll.create_clkout(soc.crg.cd_clk_256fs, sample_rate * 256)
 
-class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, use_internal_osc=False, sdram_rate="1:1"):
-        self.rst    = Signal()
-        self.cd_sys = ClockDomain()
-        if sdram_rate == "1:2":
-            self.cd_sys2x    = ClockDomain()
-            self.cd_sys2x_ps = ClockDomain()
-        else:
-            self.cd_sys_ps = ClockDomain()
+    # Create 1*Fs clock domain using a division register
+    soc.crg.cd_clk_fs = ClockDomain()
+    clkdiv_fs = Signal(8)
+    soc.sync.clk_256fs += clkdiv_fs.eq(clkdiv_fs+1)
+    soc.comb += soc.crg.cd_clk_fs.clk.eq(clkdiv_fs[-1])
 
-        # # #
+    # Now instantiate a EurorackPmod.
+    eurorack_pmod_pads = soc.platform.request("eurorack_pmod_p2b")
+    eurorack_pmod = EurorackPmod(soc.platform, eurorack_pmod_pads)
 
-        # Clk / Rst
-        if not use_internal_osc:
-            clk = platform.request("clk25")
-            clk_freq = 25e6
-        else:
-            clk = Signal()
-            div = 5
-            self.specials += Instance("OSCG",
-                p_DIV = div,
-                o_OSC = clk
-            )
-            clk_freq = 310e6/div
+    # Pipe inputs straight to outputs.
+    soc.comb += [
+        eurorack_pmod.cal_out0.eq(eurorack_pmod.cal_in0),
+        eurorack_pmod.cal_out1.eq(eurorack_pmod.cal_in1),
+        eurorack_pmod.cal_out2.eq(eurorack_pmod.cal_in2),
+        eurorack_pmod.cal_out3.eq(eurorack_pmod.cal_in3),
+    ]
 
-        self.rst_n = platform.request("cpu_reset_n")
-
-        # PLL
-        self.pll = pll = ECP5PLL()
-        self.comb += pll.reset.eq(~self.rst_n | self.rst)
-        pll.register_clkin(clk, clk_freq)
-        pll.create_clkout(self.cd_sys,    sys_clk_freq)
-        if sdram_rate == "1:2":
-            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
-            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180) # Idealy 90° but needs to be increased.
-        else:
-           pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=180) # Idealy 90° but needs to be increased.
-
-
-        # SDRAM clock
-        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
-        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
-
-# BaseSoC ------------------------------------------------------------------------------------------
-
-class BaseSoC(SoCCore):
-    def __init__(self, board="i5", revision="7.0", toolchain="trellis", sys_clk_freq=60e6,
-        use_internal_osc       = False,
-        sdram_rate             = "1:1",
-        **kwargs):
-        board = board.lower()
-        assert board in ["i5", "i9"]
-        platform = colorlight_i5.Platform(board=board, revision=revision, toolchain=toolchain)
-
-        # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq,
-            use_internal_osc = use_internal_osc,
-            sdram_rate       = sdram_rate
-        )
-
-        # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, int(sys_clk_freq), ident = "LiteX SoC on Colorlight " + board.upper(), **kwargs)
-
-        # SPI Flash --------------------------------------------------------------------------------
-        if board == "i5":
-            from litespi.modules import GD25Q16 as SpiFlashModule
-        if board == "i9":
-            from litespi.modules import W25Q64 as SpiFlashModule
-
-        from litespi.opcodes import SpiNorFlashOpCodes as Codes
-        self.add_spi_flash(mode="1x", module=SpiFlashModule(Codes.READ_1_1_1))
-
-        # SDR SDRAM --------------------------------------------------------------------------------
-        if not self.integrated_main_ram_size:
-            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
-            self.sdrphy = sdrphy_cls(platform.request("sdram"))
-            self.add_sdram("sdram",
-                phy           = self.sdrphy,
-                module        = M12L64322A(sys_clk_freq, sdram_rate),
-                l2_cache_size = kwargs.get("l2_size", 8192)
-            )
-
-    def add_eurorack_pmod(self):
-        eurorack_pmod_pads = self.platform.request("eurorack_pmod_p2b")
-        eurorack_pmod = EurorackPmod(self.platform, eurorack_pmod_pads)
-        # Pipe inputs straight to outputs.
-        self.comb += [
-            eurorack_pmod.cal_out0.eq(eurorack_pmod.cal_in0),
-            eurorack_pmod.cal_out1.eq(eurorack_pmod.cal_in1),
-            eurorack_pmod.cal_out2.eq(eurorack_pmod.cal_in2),
-            eurorack_pmod.cal_out3.eq(eurorack_pmod.cal_in3),
-        ]
-        self.add_module("eurorack_pmod0", eurorack_pmod)
-
-
-# Build --------------------------------------------------------------------------------------------
+    soc.add_module("eurorack_pmod0", eurorack_pmod)
 
 def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=colorlight_i5.Platform, description="LiteX SoC on Colorlight I5.")
     parser.add_target_argument("--board",            default="i5",             help="Board type (i5).")
     parser.add_target_argument("--revision",         default="7.0",            help="Board revision (7.0).")
-    parser.add_target_argument("--sys-clk-freq",     default=12e6, type=float, help="System clock frequency.")
-    parser.add_target_argument("--use-internal-osc", action="store_true", help="Use internal oscillator.")
-    parser.add_target_argument("--sdram-rate",       default="1:1",       help="SDRAM Rate (1:1 Full Rate or 1:2 Half Rate).")
+    parser.add_target_argument("--sys-clk-freq",     default=60e6, type=float, help="System clock frequency.")
     viopts = parser.target_group.add_mutually_exclusive_group()
     args = parser.parse_args()
-
-    # TODO: `eurorack-pmod` gateware currently assumes 12MHz system clock, this
-    # should be automatically derived from its own PLL at some point..
-    assert(args.sys_clk_freq == 12e6)
 
     soc = BaseSoC(board=args.board, revision=args.revision,
         toolchain              = args.toolchain,
         sys_clk_freq           = args.sys_clk_freq,
-        use_internal_osc       = args.use_internal_osc,
-        sdram_rate             = args.sdram_rate,
         **parser.soc_argdict
     )
-    soc.platform.add_extension(_io_eurorack_pmod)
 
-    soc.add_eurorack_pmod()
+    add_eurorack_pmod(soc)
 
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:
         builder.build(**parser.toolchain_argdict)
-
-    if args.load:
-        prog = soc.platform.create_programmer()
-        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/example-ecpix-5.py
+++ b/example-ecpix-5.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# This variable defines all the external programs that this module
+# relies on.  lxbuildenv reads this variable in order to ensure
+# the build will finish without exiting due to missing third-party
+# programs.
+LX_DEPENDENCIES = ["riscv", "nextpnr-ecp5", "yosys"]
+
+# Import lxbuildenv to integrate the deps/ directory
+import lxbuildenv
+
+from litex_boards.targets.lambdaconcept_ecpix5 import *
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=lambdaconcept_ecpix5.Platform, description="LiteX SoC on ECPIX-5.")
+    parser.add_target_argument("--device",          default="85F",            help="ECP5 device (45F or 85F).")
+    parser.add_target_argument("--sys-clk-freq",    default=75e6, type=float, help="System clock frequency.")
+
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        device                 = args.device,
+        sys_clk_freq           = args.sys_clk_freq,
+        toolchain              = args.toolchain,
+        **parser.soc_argdict
+    )
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+if __name__ == "__main__":
+    main()

--- a/example-ecpix-5.py
+++ b/example-ecpix-5.py
@@ -9,7 +9,54 @@ LX_DEPENDENCIES = ["riscv", "nextpnr-ecp5", "yosys"]
 # Import lxbuildenv to integrate the deps/ directory
 import lxbuildenv
 
+from litex.build.generic_platform import *
+from litex.soc.cores.clock import *
+
 from litex_boards.targets.lambdaconcept_ecpix5 import *
+
+from eurorack_pmod_migen.core import *
+from eurorack_pmod_migen.blocks import *
+
+_io_eurorack_pmod = [
+    ("eurorack_pmod_p0", 0,
+        Subsignal("mclk",    Pins("W26")),
+        Subsignal("pdn",     Pins("V26")),
+        Subsignal("i2c_sda", Pins("U26")),
+        Subsignal("i2c_scl", Pins("T26")),
+        Subsignal("sdin1",   Pins("T25")),
+        Subsignal("sdout1",  Pins("U25")),
+        Subsignal("lrck",    Pins("U24")),
+        Subsignal("bick",    Pins("V24")),
+        IOStandard("LVCMOS33")
+    ),
+]
+
+def add_eurorack_pmod(soc, sample_rate=48000):
+    soc.platform.add_extension(_io_eurorack_pmod)
+
+    # Create 256*Fs clock domain
+    soc.crg.cd_clk_256fs = ClockDomain()
+    soc.crg.pll.create_clkout(soc.crg.cd_clk_256fs, sample_rate * 256)
+
+    # Create 1*Fs clock domain using a division register
+    soc.crg.cd_clk_fs = ClockDomain()
+    clkdiv_fs = Signal(8)
+    soc.sync.clk_256fs += clkdiv_fs.eq(clkdiv_fs+1)
+    soc.comb += soc.crg.cd_clk_fs.clk.eq(clkdiv_fs[-1])
+
+    # Now instantiate a EurorackPmod.
+    eurorack_pmod_pads = soc.platform.request("eurorack_pmod_p0")
+    eurorack_pmod = EurorackPmod(soc.platform, eurorack_pmod_pads)
+
+    # Pipe inputs straight to outputs.
+    soc.comb += [
+        eurorack_pmod.cal_out0.eq(eurorack_pmod.cal_in0),
+        eurorack_pmod.cal_out1.eq(eurorack_pmod.cal_in1),
+        eurorack_pmod.cal_out2.eq(eurorack_pmod.cal_in2),
+        eurorack_pmod.cal_out3.eq(eurorack_pmod.cal_in3),
+    ]
+
+    soc.add_module("eurorack_pmod0", eurorack_pmod)
 
 def main():
     from litex.build.parser import LiteXArgumentParser
@@ -25,6 +72,9 @@ def main():
         toolchain              = args.toolchain,
         **parser.soc_argdict
     )
+
+    add_eurorack_pmod(soc)
+
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:
         builder.build(**parser.toolchain_argdict)

--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e
 
-export BUILD_DIR=`pwd`/../build/lambdaconcept_ecpix5
+if [[ -z "$BOARD" ]]; then
+    echo "Must provide BOARD (e.g. $ BOARD='colorlight_i5' ./build.sh)" 1>&2
+    echo "Existing builds are" $(ls `pwd`/../build)
+    exit 1
+fi
+
+export BUILD_DIR=`pwd`/../build/${BOARD}
 
 # DEFMT logging level is fixed at firmware compile time.
 # You can use this to switch logging off completely.

--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export BUILD_DIR=`pwd`/../build/colorlight_i5
+export BUILD_DIR=`pwd`/../build/lambdaconcept_ecpix5
 
 # DEFMT logging level is fixed at firmware compile time.
 # You can use this to switch logging off completely.
@@ -18,4 +18,4 @@ cd $FW_ROOT/litex-fw
 cargo build --target=riscv32imac-unknown-none-elf --release
 
 # Copy it into a binary that litex_term can upload.
-riscv-none-elf-objcopy target/riscv32imac-unknown-none-elf/release/litex-fw -O binary $BUILD_DIR/rust-fw.bin
+riscv64-elf-objcopy target/riscv32imac-unknown-none-elf/release/litex-fw -O binary $BUILD_DIR/rust-fw.bin

--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -9,6 +9,8 @@ export DEFMT_LOG=debug
 
 FW_ROOT=`pwd`
 
+OBJCOPY=${OBJCOPY:=riscv-none-elf-objcopy}
+
 # Generate the Rust CSR bindings spat out by the LiteX SOC generated.
 cd $FW_ROOT/litex-pac/src
 svd2rust -i $BUILD_DIR/csr.svd --target riscv
@@ -18,4 +20,4 @@ cd $FW_ROOT/litex-fw
 cargo build --target=riscv32imac-unknown-none-elf --release
 
 # Copy it into a binary that litex_term can upload.
-riscv64-elf-objcopy target/riscv32imac-unknown-none-elf/release/litex-fw -O binary $BUILD_DIR/rust-fw.bin
+${OBJCOPY} target/riscv32imac-unknown-none-elf/release/litex-fw -O binary $BUILD_DIR/rust-fw.bin

--- a/firmware/litex-fw/src/main.rs
+++ b/firmware/litex-fw/src/main.rs
@@ -80,12 +80,14 @@ fn main() -> ! {
     defmt::info!("Starting main loop --");
 
     loop {
+        /*
         defmt::info!("jack_detect {=u8:x}", peripherals.EURORACK_PMOD0.csr_jack.read().bits() as u8);
         defmt::info!("input0 {}", peripherals.EURORACK_PMOD0.csr_cal_in0.read().bits() as i16);
         defmt::info!("input1 {}", peripherals.EURORACK_PMOD0.csr_cal_in1.read().bits() as i16);
         defmt::info!("input2 {}", peripherals.EURORACK_PMOD0.csr_cal_in2.read().bits() as i16);
         defmt::info!("input3 {}", peripherals.EURORACK_PMOD0.csr_cal_in3.read().bits() as i16);
         defmt::info!("serial {=u32:x}", peripherals.EURORACK_PMOD0.csr_eeprom_serial.read().bits() as u32);
+        */
         timer.delay_ms(1000u32);
         defmt::info!("tick - elapsed {} sec", elapsed);
         elapsed += 1.0f32;

--- a/firmware/litex-fw/src/main.rs
+++ b/firmware/litex-fw/src/main.rs
@@ -80,14 +80,12 @@ fn main() -> ! {
     defmt::info!("Starting main loop --");
 
     loop {
-        /*
         defmt::info!("jack_detect {=u8:x}", peripherals.EURORACK_PMOD0.csr_jack.read().bits() as u8);
         defmt::info!("input0 {}", peripherals.EURORACK_PMOD0.csr_cal_in0.read().bits() as i16);
         defmt::info!("input1 {}", peripherals.EURORACK_PMOD0.csr_cal_in1.read().bits() as i16);
         defmt::info!("input2 {}", peripherals.EURORACK_PMOD0.csr_cal_in2.read().bits() as i16);
         defmt::info!("input3 {}", peripherals.EURORACK_PMOD0.csr_cal_in3.read().bits() as i16);
         defmt::info!("serial {=u32:x}", peripherals.EURORACK_PMOD0.csr_eeprom_serial.read().bits() as u32);
-        */
         timer.delay_ms(1000u32);
         defmt::info!("tick - elapsed {} sec", elapsed);
         elapsed += 1.0f32;


### PR DESCRIPTION
- Uses new clocking architecture from eurorack-pmod repository which is yet to be tested on hardware.